### PR TITLE
PHP8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /composer.lock
 /phpunit.xml
 /vendor/
+/.idea
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
+  - 8.0
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
         "source": "https://github.com/ramsey/http-range"
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "psr/http-message": "^1.0",
         "ramsey/collection": "^1.0"
     },
     "require-dev": {
-        "jakub-onderka/php-parallel-lint": "^1.0",
-        "mockery/mockery": "^1.2",
-        "phpstan/phpstan": "^0.10.3",
-        "phpstan/phpstan-mockery": "^0.10.2",
-        "phpunit/phpunit": "^7.3",
+        "php-parallel-lint/php-parallel-lint": "^1.0",
+        "mockery/mockery": "^1.3",
+        "phpstan/phpstan": "^0.12.0",
+        "phpstan/phpstan-mockery": "^0.12.0",
+        "phpunit/phpunit": "^7.3|^8.0",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {

--- a/tests/RangeTest.php
+++ b/tests/RangeTest.php
@@ -16,7 +16,7 @@ class RangeTest extends TestCase
     private $unit;
     private $unitFactory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $rangeHeader = ['bytes=100-200'];
 

--- a/tests/Unit/AbstractUnitTest.php
+++ b/tests/Unit/AbstractUnitTest.php
@@ -10,7 +10,7 @@ class AbstractUnitTest extends TestCase
 {
     protected $unit;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->unit = \Mockery::mock(
             AbstractUnit::class,


### PR DESCRIPTION
This PR adds PHP8 support

## How Has This Been Tested?
Tested using Composer's `--prefer-lowest` both on PHP7 and PHP8

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I ran `composer phpunit` locally and there were no failures or errors.
